### PR TITLE
Fix configured theme not being set

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,8 +1,9 @@
 {%- import "macros/feed.html" as feed_macros -%}
 {%- import "macros/post.html" as post_macros -%}
+{% set configured_theme = config.extra.color_scheme | default(value = "terminus") -%}
 
 <!doctype html>
-<html lang="{{ lang }}">
+<html lang="{{ lang }}" {%- if not config.extra.color_scheme_switcher %} data-theme="{{ configured_theme }}"{%- endif -%}>
 
 <head>
     <meta charset="utf-8">
@@ -141,8 +142,7 @@
     {%- endif %}
 </head>
 
-{% set default_theme = config.extra.color_scheme | default(value = "terminus") -%}
-<body class="layout-{{ config.extra.layout }}" {%- if config.extra.color_scheme_switcher %} data-theme="{{ default_theme }}" {%- endif -%}>
+<body class="layout-{{ config.extra.layout }}" {%- if config.extra.color_scheme_switcher %} data-theme="{{ configured_theme }}" {%- endif -%}>
     <header class="header">
         {% filter indent -%}{%- filter indent -%}
         {%- block header -%}


### PR DESCRIPTION
I noticed when changing the following option in my `config.toml`

```toml
[extra]
# example
color_scheme = "solar-flare"
```

the theme would not actually change. I am not using the theme switcher so I realized that, based on where the root variables are configured in the Sass here: https://github.com/ebkalderon/terminus/blob/main/sass/css/_themes.scss, if I set the appropriate `data-theme` element on the root `html` element, the theme switching works via `config.toml`.

I also made sure to only enable that if the theme switcher is not enabled, since that can be used to do the actual switching instead (I haven't tested the theme switcher so cannot verify -- I prefer less JS if possible).

Let me know if you need anything else, appreciate such a nice theme port!
