### PR TITLE
Support Zola 0.22, drop compatibility with older versions

### DIFF
--- a/.github/workflows/zola.yml
+++ b/.github/workflows/zola.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@main
     - name: Build only
-      uses: shalzz/zola-deploy-action@v0.21.0
+      uses: shalzz/zola-deploy-action@v0.22.1
       env:
         BUILD_DIR: .
         TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
     - name: Patch CSS font-face paths
       run: sed -i "s,url('/,url('/terminus/,g" ./sass/css/_fonts.scss
     - name: Build and deploy
-      uses: shalzz/zola-deploy-action@v0.21.0
+      uses: shalzz/zola-deploy-action@v0.22.1
       env:
         PAGES_BRANCH: gh-pages
         BUILD_DIR: .

--- a/config.toml
+++ b/config.toml
@@ -32,13 +32,6 @@ taxonomies = [
 build_search_index = true
 
 [markdown]
-# Whether to do syntax highlighting
-# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
-highlight_code = true
-
-# The theme to use for code highlighting.
-# See below for list of allowed values.
-highlight_theme = "monokai"
 
 # When set to "true", emoji aliases translated to their corresponding
 # Unicode emoji equivalent in the rendered Markdown files. (e.g.: :smile: => 😄)
@@ -49,6 +42,15 @@ bottom_footnotes = true
 
 # When set to "true", support for GitHub-style alerts, a.k.a. callouts or admonitions, is enabled in the Markdown parser.
 github_alerts = true
+
+[markdown.highlighting]
+# Whether to use inline hex colours ("inline") or CSS classes ("class").
+# See https://www.getzola.org/documentation/content/syntax-highlighting/ for details.
+style = "inline"
+
+# The theme to use for code highlighting.
+# See https://github.com/getzola/giallo?tab=readme-ov-file#themes for the list of allowed values.
+theme = "monokai"
 
 [extra]
 close_responsive_menu_on_resize = true

--- a/sass/css/_code.scss
+++ b/sass/css/_code.scss
@@ -1,13 +1,3 @@
-// FIXME: Refactor this giant mess of CSS to use flexbox and/or relative
-// elements only once Zola outputs proper HTML for code block headings and/or a
-// "copy to clipboard" button. Until then, we make do with `::before`/`::after`
-// pseudo-elements and many hacks (absolute positioning, negative margins).
-//
-// Links to relevant Zola issues:
-//
-// https://github.com/getzola/zola/issues/1851
-// https://github.com/getzola/zola/issues/2586
-
 :root {
     --code-border: color-mix(in srgb, var(--text-color) 10%, transparent);
 }
@@ -16,8 +6,24 @@ $header-padding-vertical: 6px;
 $header-border-thickness: 1px;
 $line-number-color: color-mix(in srgb, var(--text-color) 53%, transparent);
 
+// Mandatory Giallo CSS (see https://www.getzola.org/documentation/content/syntax-highlighting/)
+.giallo-l {
+    flex: 0 0 100%;
+    margin-inline: -10px;
+    padding-inline: 10px;
+}
+.giallo-ln {
+    display: inline-block;
+    user-select: none;
+    margin-inline-end: 20px;
+    min-width: 2ch;
+    text-align: end;
+    color: $line-number-color;
+}
+
 .copy-button {
     position: absolute;
+    z-index: 1;
     top: $header-padding-vertical;
     right: 10px;
     padding: 3px 8px;
@@ -32,29 +38,44 @@ $line-number-color: color-mix(in srgb, var(--text-color) 53%, transparent);
     }
 }
 
-pre[data-lang] {
+pre.giallo {
     display: block;
     position: relative;
     padding: 0;
     overflow-y: hidden;
 
-    &::before {
+    // Monokai (and some other themes) emit background-color on whitespace-only
+    // spans. Strip it so spaces don't render as colored blocks. Exclude .giallo-l
+    // spans, which carry the highlight background for marked lines.
+    span:not(.giallo-l)[style*="background-color"] {
+        background-color: transparent !important;
+    }
+
+    // Language header bar, driven by the data-lang attribute on <code>.
+    code[data-lang]:not([data-lang="plain"])::before {
         content: attr(data-lang);
         display: block;
         padding: $header-padding-vertical 10px;
+        margin: -10px -10px 10px -10px;
         border-bottom: $header-border-thickness solid var(--code-border);
         color: $line-number-color;
         font-size: calc(var(--font-size) * 0.8);
         text-transform: uppercase;
         line-height: 21px;
+        position: sticky;
+        width: calc(100% + 20px);
+        left: -10px;
     }
 
     code[data-lang] {
-        display: block;
+        display: flex;
+        flex-direction: column;
+        flex-wrap: wrap;
         overflow-x: auto;
         padding: 10px;
 
-        &[data-name]::before {
+        // Filename label, positioned in the header bar area.
+        &[data-name]::after {
             content: attr(data-name);
             position: absolute;
             top: 0;
@@ -68,37 +89,11 @@ pre[data-lang] {
             overflow: hidden;
             text-overflow: ellipsis;
         }
+    }
 
-        &:has(.copy-button)::before {
-            @media screen {
-                right: calc(4.5rem + 10px);
-            }
-        }
-
-        mark {
-            margin-inline: -10px;
-            padding-inline: 10px;
-            color: unset;
-        }
-
-        table {
-            margin-block: 0;
-            width: 100%;
-            border-collapse: collapse;
-
-            td,
-            th,
-            tr {
-                border: none;
-                padding: 0;
-            }
-
-            tr td:first-child {
-                color: $line-number-color;
-                text-align: end;
-                user-select: none;
-                padding-inline-end: 20px;
-            }
+    &:has(.copy-button) code[data-name]::after {
+        @media screen {
+            right: calc(4.5rem + 10px);
         }
     }
 }

--- a/static/js/copy-code-to-clipboard.js
+++ b/static/js/copy-code-to-clipboard.js
@@ -1,14 +1,17 @@
-const codeBlocks = document.querySelectorAll("pre code[data-lang]");
+const codeBlocks = document.querySelectorAll("pre.giallo code[data-lang]:not([data-lang='plain'])");
 
 for (const codeBlock of codeBlocks) {
-    let content;
-    if (codeBlock.parentElement.hasAttribute("data-linenos")) {
-        content = [...codeBlock.querySelectorAll("tr")]
-            .map((row) => row.querySelector("td:last-child")?.innerText ?? "")
-            .join("");
-    } else {
-        content = codeBlock.innerText.split("\n").filter(Boolean).join("\n");
-    }
+    const preBlock = codeBlock.parentElement;
+
+    // Giallo wraps every line in a .giallo-l span, with optional .giallo-ln spans
+    // for line numbers. Extract text from each line span, stripping line numbers.
+    const content = [...codeBlock.querySelectorAll(".giallo-l")]
+        .map((line) => {
+            const clone = line.cloneNode(true);
+            clone.querySelectorAll(".giallo-ln").forEach((ln) => ln.remove());
+            return clone.textContent;
+        })
+        .join("\n");
 
     if (navigator.clipboard !== undefined) {
         const copyButton = document.createElement("button");
@@ -21,6 +24,6 @@ for (const codeBlock of codeBlocks) {
             setTimeout(() => copyButton.innerText = "Copy", 1000);
         });
 
-        codeBlock.prepend(copyButton);
+        preBlock.prepend(copyButton);
     }
 }

--- a/templates/partials/content_security_policy.html
+++ b/templates/partials/content_security_policy.html
@@ -15,8 +15,8 @@
         {%- set allowed_domains = allowed_domains | concat(with=img_src) -%}
     {%- endif -%}
 
-    {#- Allow inline CSS if Zola syntax highlighting is enabled -#}
-    {%- if config.markdown.highlight_code == true -%}
+    {#- Allow inline CSS if Zola syntax highlighting uses inline styles -#}
+    {%- if config.markdown.highlighting.style == "inline" -%}
         {%- set style_src = load_data(literal=`{"directive": "style-src-attr", "domains": ["'unsafe-inline'"]}`, format="json") -%}
         {%- set allowed_domains = allowed_domains | concat(with=style_src) -%}
     {%- endif -%}

--- a/theme.toml
+++ b/theme.toml
@@ -3,7 +3,7 @@ description = "A dark duotone retro theme for Zola"
 tags = ["dark", "blog", "minimal", "personal", "responsive", "seo"]
 license = "MIT"
 homepage = "https://github.com/ebkalderon/terminus"
-min_version = "0.20.0"
+min_version = "0.22.0"
 demo = "https://ebkalderon.github.io/terminus/"
 
 [author]


### PR DESCRIPTION
Closes #13

Migrates the theme from Syntect to Giallo for Zola 0.22 compatibility. This breaks support for Zola <0.22.

Changes:
- Replace `highlight_code`/`highlight_theme` config with `[markdown.highlighting]` section
- Update CSP template to check `config.markdown.highlighting.style` instead of `config.markdown.highlight_code`
- Add conditional Giallo CSS links in `base.html` for `style = "class"` users
- Add mandatory `.giallo-l`/`.giallo-ln` classes, remove dead table-based line number styles
- Move copy button from `<code>` to `<pre>` and update JS for Giallo's span-based output
- Bump `min_version` to `0.22.0`

Testing:
- Ran `zola serve` and opened the locally running instance; no errors nor differences observed
<img width="801" height="796" alt="Screenshot 2026-02-23 at 08 17 12" src="https://github.com/user-attachments/assets/048a12d7-9dd5-433e-b4a9-f541f47163a1" />
