### PR TITLE
Mark logo title as safe for the template engine

### DIFF
--- a/templates/partials/logo.html
+++ b/templates/partials/logo.html
@@ -1,3 +1,3 @@
 <a href="{{ get_url(path='/', lang=lang) }}">
-    <span class="logo">{{ config.extra.header_title | default(value=config.title) }}</span>
+    <span class="logo">{{ config.extra.header_title | default(value=config.title) | safe }}</span>
 </a>


### PR DESCRIPTION
This is to avoid html escapes
Fixes https://github.com/ebkalderon/terminus/issues/15