### PR TITLE
Added a logo image in the header

### DIFF
--- a/sass/css/_header.scss
+++ b/sass/css/_header.scss
@@ -43,6 +43,12 @@
     text-decoration: none;
 }
 
+.logo-img {
+    display: inline;
+    height: var(--line-height);
+    margin: 0px;
+}
+
 @media print {
     .header {
         display: none;

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,11 @@
     <link rel="preload" href="{{ get_url(path="fonts/FiraCode-Regular.woff2") }}" as="font" type="font/woff2" crossorigin="anonymous">
     <link rel="preload" href="{{ get_url(path="fonts/FiraCode-Bold.woff2") }}" as="font" type="font/woff2" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ get_url(path="css/style.css", cachebust=true) }}">
+    {%- if config.extra.stylesheets %}
+    {%- for stylesheet in config.extra.stylesheets %}
+    <link rel="stylesheet" href="{{ get_url(path=stylesheet, cachebust=true) }}">
+    {% endfor -%}
+    {%- endif %}
     {%- if page.extra.stylesheets or section.extra.stylesheets %}
     {%- for stylesheet in page.extra.stylesheets | default(value=section.extra.stylesheets) %}
     <link rel="stylesheet" href="{{ get_url(path=stylesheet, cachebust=true) }}">

--- a/templates/partials/logo.html
+++ b/templates/partials/logo.html
@@ -2,7 +2,7 @@
     {% if config.extra.header_logo %}
     <span class="logo"><img
             style="width: {{ config.extra.header_logo_width | default(value='auto') }}; height: {{ config.extra.header_logo_height | default(value='auto') }}"
-            src="{{ config.extra.header_logo }}" /></span>
+            src="{{ get_url(path=config.extra.header_logo, cachebust=true) }}" /></span>
     {% else %}
     <span class="logo">{{ config.extra.header_title | default(value=config.title) | safe }}</span>
     {% endif %}

--- a/templates/partials/logo.html
+++ b/templates/partials/logo.html
@@ -1,3 +1,9 @@
 <a href="{{ get_url(path='/', lang=lang) }}">
+    {% if config.extra.header_logo %}
+    <span class="logo"><img
+            style="width: {{ config.extra.header_logo_width | default(value='auto') }}; height: {{ config.extra.header_logo_height | default(value='auto') }}"
+            src="{{ config.extra.header_logo }}" /></span>
+    {% else %}
     <span class="logo">{{ config.extra.header_title | default(value=config.title) | safe }}</span>
+    {% endif %}
 </a>

--- a/templates/partials/logo.html
+++ b/templates/partials/logo.html
@@ -1,9 +1,9 @@
 <a href="{{ get_url(path='/', lang=lang) }}">
-    {% if config.extra.header_logo %}
-    <span class="logo"><img
-            style="width: {{ config.extra.header_logo_width | default(value='auto') }}; height: {{ config.extra.header_logo_height | default(value='auto') }}"
-            src="{{ get_url(path=config.extra.header_logo, cachebust=true) }}" /></span>
-    {% else %}
-    <span class="logo">{{ config.extra.header_title | default(value=config.title) | safe }}</span>
-    {% endif %}
+    <span class="logo">
+        {%- if config.extra.header_logo -%}
+            <img class="logo-img" src="{{ get_url(path=config.extra.header_logo, cachebust=true) }}" alt="{{ config.extra.header_title | default(value=config.title) | safe }}">
+        {%- else -%}
+            {{ config.extra.header_title | default(value=config.title) | safe }}
+        {%- endif -%}
+    </span>
 </a>

--- a/theme.toml
+++ b/theme.toml
@@ -53,7 +53,7 @@ copyright = "© $YEAR $AUTHOR :: Powered by [Zola](https://www.getzola.org) :: T
 # header_title = "My custom title"
 
 # Sets a custom logo using an image file. Can be an SVG image.
-# header_logo = "/images/logo/logo.svg"
+# header_logo = "images/logo/logo.svg"
 # To preserve aspect ratio, only specify either the width or the height of the image. The other
 # one will be automatically parsed as 'auto'.
 # For compatiblity with different screen sizes, use relative values and specify the width.

--- a/theme.toml
+++ b/theme.toml
@@ -52,6 +52,14 @@ copyright = "© $YEAR $AUTHOR :: Powered by [Zola](https://www.getzola.org) :: T
 # Sets the header text to a value other than the contents of `config.title`.
 # header_title = "My custom title"
 
+# Sets a custom logo using an image file. Can be an SVG image.
+# header_logo = "/images/logo/logo.svg"
+# To preserve aspect ratio, only specify either the width or the height of the image. The other
+# one will be automatically parsed as 'auto'.
+# For compatiblity with different screen sizes, use relative values and specify the width.
+# header_logo_width = "16vw"
+# header_logo_height = "auto"
+
 # Enable KaTeX support for all posts (requires JS).
 katex = false
 
@@ -65,7 +73,7 @@ show_default_author = true
 #     { name = "internal link 1", url = "resume.pdf" },
 #     { name = "internal link 2", url = "blog", trailing_slash = true },
 #     { name = "external link", url = "https://github.com", new_tab = true },
-# }
+# ]
 
 # socials = [
 #     { name = "email", url = "mailto:hello@example.com" },

--- a/theme.toml
+++ b/theme.toml
@@ -29,6 +29,13 @@ color_scheme = "terminus"
 # Enable dynamic color scheme switcher in site navigation bar (requires JS).
 color_scheme_switcher = false
 
+# Add global stylesheets to support user-defined customisation.
+#
+# Global styles added through stylesheets here may be overridden on individual pages or sections 
+# by specifying corresponding styles and setting them up for use through
+# `page.extra.stylesheets` or `section.extra.stylesheets`, respectively.
+# stylesheets = []
+
 # Add "copy to clipboard" button to all fenced code blocks (requires JS).
 #
 # Global setting may be overridden on individual pages or sections by setting

--- a/theme.toml
+++ b/theme.toml
@@ -54,11 +54,6 @@ copyright = "© $YEAR $AUTHOR :: Powered by [Zola](https://www.getzola.org) :: T
 
 # Sets a custom logo using an image file. Can be an SVG image.
 # header_logo = "images/logo/logo.svg"
-# To preserve aspect ratio, only specify either the width or the height of the image. The other
-# one will be automatically parsed as 'auto'.
-# For compatiblity with different screen sizes, use relative values and specify the width.
-# header_logo_width = "16vw"
-# header_logo_height = "auto"
 
 # Enable KaTeX support for all posts (requires JS).
 katex = false


### PR DESCRIPTION
- Added a mechanism to display a logo image, raster or vector (SVG), in the header.
- Corrected the documentation of `main_menu` in theme.toml where the closing `]` was mistakenly written as `}`.

Fixes #18 