### PR TITLE
Fix section page fallback to use section.pages instead of term.pages

### DIFF
--- a/templates/section.html
+++ b/templates/section.html
@@ -26,7 +26,7 @@
     {{ section.content | indent | safe }}
 </header>
 {%- endif -%}
-{%- for page in paginator.pages | default(value=term.pages) -%}
+{%- for page in paginator.pages | default(value=section.pages) -%}
 {{ post_macros::excerpt(page=page) }}
 {% endfor -%}
 {% include "partials/pagination.html" %}


### PR DESCRIPTION
Fixed rendering on sections without pagination.

This fixes the issue described in #19. 