### PR TITLE
Add head block to base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -153,7 +153,10 @@
     {%- endif -%}
     {%- if config.extra.fediverse_creator %}
     <meta name="fediverse:creator" content="{{ config.extra.fediverse_creator }}">
-    {%- endif %}
+    {%- endif -%}
+
+    {%- block head -%}
+    {%- endblock %}
 </head>
 
 <body class="layout-{{ config.extra.layout }}" data-theme="{{ config.extra.color_scheme | default(value = "terminus") }}">


### PR DESCRIPTION
This change adds an head block in base template. That way it could be easier to add some extra tag in `<head/>` like custom javascript file load, `<meta/>` tags, etc.

