### PR TITLE
Add SynthWave '84 color scheme

### DIFF
--- a/sass/css/_themes.scss
+++ b/sass/css/_themes.scss
@@ -103,4 +103,15 @@
         --accent-color: #89b4fa;
         --footnote-color: rgba(186, 194, 222, 0.7);
     }
+
+    // SynthWave '84 theme
+    // Inspired by the SynthWave '84 VS Code theme by Robb Owen
+    // (https://github.com/robb0wen/synthwave-vscode)
+    &:has(body[data-theme="synthwave-84"]) {
+        --background-color: #262335;
+        --text-color: #ffffff;
+        --accent-color: #ff7edb;
+        --footnote-color: rgba(255, 255, 255, 0.6);
+    }
+
 }

--- a/static/js/theme-switcher.js
+++ b/static/js/theme-switcher.js
@@ -16,6 +16,7 @@ class ThemeSwitcher {
       "catppuccin-frappe": "😸 Catppuccin Frappé",
       "catppuccin-macchiato": "😻 Catppuccin Macchiato",
       "catppuccin-mocha": "😼 Catppuccin Mocha",
+      "synthwave-84": "🎹 SynthWave '84",
     };
 
     this.currentTheme = this.getStoredTheme();

--- a/theme.toml
+++ b/theme.toml
@@ -23,7 +23,8 @@ close_responsive_menu_on_resize = true
 #
 # Supported color schemes: "terminus", "tokyo-night", "solarized-dark", "nord",
 # "one-dark", "gruvbox-dark", "oled-abyss", "solar-flare", "catppuccin-latte",
-# "catppuccin-frappe", "catppuccin-macchiato", "catppuccin-mocha".
+# "catppuccin-frappe", "catppuccin-macchiato", "catppuccin-mocha",
+# "synthwave-84".
 color_scheme = "terminus"
 
 # Enable dynamic color scheme switcher in site navigation bar (requires JS).


### PR DESCRIPTION
Adds a SynthWave '84 color scheme inspired by [Robb Owen's VS Code theme](https://github.com/robb0wen/synthwave-vscode).

Changes:
* New theme definition in _themes.scss
* Updated supported color schemes list in theme.toml

Screenshot:
<img width="909" height="861" alt="Screenshot 2026-05-24 at 14 00 51" src="https://github.com/user-attachments/assets/7ba41416-e6de-42a1-a695-8db8ccf30ab5" />
