### PR TITLE
fix: prevent iOS Safari from inflating code block text

### DIFF
--- a/sass/css/_main.scss
+++ b/sass/css/_main.scss
@@ -38,6 +38,7 @@ body {
     -webkit-font-smoothing: antialiased;
     -webkit-overflow-scrolling: touch;
     text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%;
     font-feature-settings: 'liga';
 
     &.layout-left,


### PR DESCRIPTION
Safari's automatic text size adjustment was causing some code block text to appear much larger than intended on iOS devices. Adding the -webkit-text-size-adjust property alongside the existing unprefixed version ensures Safari respects the intended font sizes.

previously vs now
<img height="350" alt="image" src="https://github.com/user-attachments/assets/a63dc171-a885-4ddb-bb34-2080aa6e8fe8" />
<img height="350" alt="image" src="https://github.com/user-attachments/assets/991220bf-b4c4-4f7b-8ddb-cc8f0ea59969" />
