### PR TITLE
Add Google Analytics support

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -154,6 +154,9 @@
     {%- if config.extra.fediverse_creator %}
     <meta name="fediverse:creator" content="{{ config.extra.fediverse_creator }}">
     {%- endif -%}
+    {%- if config.extra.google_analytics_id -%}
+    {% include "partials/google_analytics.html" %}
+    {%- endif -%}
 
     {%- block head -%}
     {%- endblock %}

--- a/templates/partials/google_analytics.html
+++ b/templates/partials/google_analytics.html
@@ -1,0 +1,8 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ config.extra.google_analytics_id }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ config.extra.google_analytics_id }}');
+</script>


### PR DESCRIPTION
Adds a new extra config `google_analytics_id` which when set will include Google Analytics tracking script.

```toml
[extra]
google_analytics_id = "G-XXXXXXXXXX"
```